### PR TITLE
users can now remove comments

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -36,3 +36,10 @@ export const postNewComment = (articleId, username, body) => {
         return comment;
     });
 }
+
+export const deleteComment = (commentId) => {
+    return ncNewsApi.delete(`/comments/${commentId}`)
+    .then((response) => {
+        return response.status === 204;
+    });
+}

--- a/src/components/ArticleComments.jsx
+++ b/src/components/ArticleComments.jsx
@@ -20,7 +20,7 @@ const ArticleComments = ({ article, newComment }) => {
     return isLoading ? <Loading /> : (
         <ul className='card-list'>
             {comments.map((comment) => (
-                <Comment key={comment.comment_id} comment={comment} />
+                <Comment key={comment.comment_id} comment={comment} setComments={setComments} />
             ))}
         </ul>
     );

--- a/src/components/Comment.jsx
+++ b/src/components/Comment.jsx
@@ -1,10 +1,39 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
+import UserContext from '../contexts/UserContext';
+import Loading from './Loading';
+import { deleteComment } from '../api';
 
-const Comment = ({ comment }) => {
+const Comment = ({ comment, setComments }) => {
+    
+    const { currentUser } = useContext(UserContext);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const handleDelete = () => {
+        setIsLoading(true);
+        deleteComment(comment.comment_id)
+        .then((success) => {
+            if (!success) {
+                alert("Failed to delete comment.");
+                return;
+            }
+            // else: 204 status, remove comment from page
+            setComments((currComments) => {
+                return currComments.filter((existingComment) => {
+                    return existingComment.comment_id !== comment.comment_id
+                });
+            });
+            alert("Deleted comment!");
+            setIsLoading(false);
+        });
+    }
+
     return (
         <li className='card'>
             <p>User: {comment.author} </p>
             <p>{comment.body}</p>
+            { comment.author === currentUser ? (
+                isLoading ? <Loading /> : <button onClick={handleDelete}>Delete</button>
+            ) : '' }
         </li>
     );
 };


### PR DESCRIPTION
* delete button only appears on comments for the currentUser (technically, this could be abused by listening/observing the request that gets sent and then modifying and replaying the request; but that's really an authentication issue on the backend; I don't think there's anything we can do about that)
* delete button will go into a loading state when the async request is sent off until the request is successful
* comments are updated within state when the request comes back as 204
* if the request comes back as anything besides 204, the user is alerted and the comment is not deleted